### PR TITLE
Fix build issues on Windows 

### DIFF
--- a/egl_probe/CMakeLists.txt
+++ b/egl_probe/CMakeLists.txt
@@ -10,11 +10,6 @@ add_executable(test_device glad/egl.cpp glad/gl.cpp test_device.cpp)
 
 IF(WIN32)
   SET(PLATFORM_LIBS)
-  IF(NOT CMAKE_CL_64)
-    # tell the compiler to use stdcall calling convention even in x86 where cdecl is default
-    # this is a simple workaround for Win32 x86 support 
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Gz")
-  ENDIF()
 ELSE(WIN32)
   SET(PLATFORM_LIBS dl pthread)
 ENDIF(WIN32)

--- a/egl_probe/CMakeLists.txt
+++ b/egl_probe/CMakeLists.txt
@@ -7,5 +7,12 @@ add_definitions(-DUSE_GLAD)
 add_executable(query_devices glad/egl.cpp glad/gl.cpp query_devices.cpp)
 add_executable(test_device glad/egl.cpp glad/gl.cpp test_device.cpp)
 
-target_link_libraries(query_devices dl pthread)
-target_link_libraries(test_device dl pthread)
+
+IF(WIN32)
+  SET(PLATFORM_LIBS)
+ELSE(WIN32)
+  SET(PLATFORM_LIBS dl pthread)
+ENDIF(WIN32)
+
+target_link_libraries(query_devices ${PLATFORM_LIBS})
+target_link_libraries(test_device ${PLATFORM_LIBS})

--- a/egl_probe/CMakeLists.txt
+++ b/egl_probe/CMakeLists.txt
@@ -10,6 +10,11 @@ add_executable(test_device glad/egl.cpp glad/gl.cpp test_device.cpp)
 
 IF(WIN32)
   SET(PLATFORM_LIBS)
+  IF(NOT CMAKE_CL_64)
+    # tell the compiler to use stdcall calling convention even in x86 where cdecl is default
+    # this is a simple workaround for Win32 x86 support 
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Gz")
+  ENDIF()
 ELSE(WIN32)
   SET(PLATFORM_LIBS dl pthread)
 ENDIF(WIN32)

--- a/egl_probe/query_devices.cpp
+++ b/egl_probe/query_devices.cpp
@@ -7,7 +7,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
-#include <unistd.h>
+#ifndef _WIN32
+  #include <unistd.h>
+#endif
 
 #ifdef USE_GLAD
   #include  <glad/egl.h>

--- a/egl_probe/test_device.cpp
+++ b/egl_probe/test_device.cpp
@@ -7,7 +7,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
-#include <unistd.h>
+#ifndef _WIN32
+  #include <unistd.h>
+#endif
 
 #ifdef USE_GLAD
   #include  <glad/egl.h>

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ class CMakeBuild(build_ext):
         os.mkdir(build_dir)
 
         # build using cmake
-        subprocess.check_call("cmake ..; make -j", cwd=build_dir, shell=True)
+        subprocess.check_call("cmake -S .. -B .", cwd=build_dir, shell=True)
+        subprocess.check_call("cmake --build .", cwd=build_dir, shell=True)
 
 
 if sys.version_info.major == 3:


### PR DESCRIPTION
Fixes #3 
- call cmake build steps so it is compatible with Windows and linux
- protect unix specific includes so they are not included in Windows
- avoid to link to unix lib in Windows